### PR TITLE
fix: createdAt default value is not a whole number

### DIFF
--- a/packages/workers-sdk/src/database/schema/base.ts
+++ b/packages/workers-sdk/src/database/schema/base.ts
@@ -3,6 +3,6 @@ import { integer, text } from 'drizzle-orm/sqlite-core'
 
 export const base = {
   id: text('id').primaryKey(),
-  createdAt: integer('created_at', { mode: 'timestamp_ms' }).default(sql`(unixepoch('subsec'))`),
+  createdAt: integer('created_at', { mode: 'timestamp_ms' }).default(sql`(unixepoch('subsec') * 1000)`),
   modifiedAt: integer('modified_at', { mode: 'timestamp_ms' }).default(sql`null`).$onUpdate(() => new Date()),
 }


### PR DESCRIPTION
- The current implementation saves the epoch time in milliseconds as a floating-point number. This pull request addresses this issue by ensuring that the epoch time is saved as a whole number.